### PR TITLE
Fix panic when sending from Discord

### DIFF
--- a/zygarde.js
+++ b/zygarde.js
@@ -292,11 +292,10 @@ client.on("message", async msg => {
     return;
   }
 
-  const sender = msg.member ? msg.member.displayName : msg.author.username;
-
   // replace spaces with dashes, which matches zephyr
   // convention
-  sender = sender.replace(/ /g, '-');
+  const sender = (msg.member ? msg.member.displayName : msg.author.username)
+    .replace(/ /g, '-');
 
   // Figure out where to bridge the message to
   const matching = [];


### PR DESCRIPTION
The line `sender = sender.replace(/ /g, '-');` caused a TypeError, because `sender` was declared as `const`. I inlined the replace so that there's no reassignment.